### PR TITLE
k6 test realm setup playbook update

### DIFF
--- a/keycloak_realm_builder/scripts/custom_usage/doc/k6-setup-automation.md
+++ b/keycloak_realm_builder/scripts/custom_usage/doc/k6-setup-automation.md
@@ -3,7 +3,7 @@
 ### Prep steps:
 - SSO instance admin credential will be needed to make API requests
 
-### Setup:
+### Setup for each k6 realm:
 - create a new realm for k6
 - create a public client for K6 auth requests - `k6`
 - create a private client for API test - `api-test`

--- a/keycloak_realm_builder/scripts/custom_usage/doc/k6-setup-automation.md
+++ b/keycloak_realm_builder/scripts/custom_usage/doc/k6-setup-automation.md
@@ -12,4 +12,5 @@
 - create list of test users
   - keycloak local users
   - with preset password
-- output list of the objects created and info needed for k6 test config
+- printout a list of the objects created and info needed for k6 test config
+- also output oc param files to apply directly with k6 openshift templates

--- a/keycloak_realm_builder/scripts/custom_usage/playbook.yml
+++ b/keycloak_realm_builder/scripts/custom_usage/playbook.yml
@@ -38,7 +38,7 @@
       - "{{ environments }}"
     loop_control: 
       loop_var: env
-    when: action == "new-realm" or action == "ocp4-setup" or action == "k6-setup"
+    when: action == "new-realm" or action == "ocp4-setup"
 
   - name: Config ocp4 realm
     include_tasks: tasks/ocp4-setup.yml
@@ -49,16 +49,6 @@
     loop_control: 
       loop_var: env
     when: action == "ocp4-setup"
-
-  - name: Config k6 realm
-    include_tasks: tasks/k6-setup.yml
-    vars:
-    - realm_data: "{{ app_realm_data }}"
-    with_items: 
-      - "{{ environments }}"
-    loop_control: 
-      loop_var: env
-    when: action == "k6-setup"
 
   - name: Add new IDPs or enable BCeID
     include_tasks: tasks/manage-idp.yml
@@ -83,4 +73,11 @@
       - "{{ environments }}"
     loop_control: 
       loop_var: env
-    when: action == "delete-realm" and delete_confirmed.user_input == "yes"
+    when: action == "delete-realm" and delete_confirmed.user_input == "yes"  
+
+  - name: Create "{{ count }}" K6 realms in total
+    include_tasks: tasks/k6-main.yml
+    vars:
+    - realm_data: "{{ app_realm_data }}"
+    with_sequence: start=0 end="{{ count | int - 1 }}"
+    when: action == "k6-setup"

--- a/keycloak_realm_builder/scripts/custom_usage/readme.md
+++ b/keycloak_realm_builder/scripts/custom_usage/readme.md
@@ -58,7 +58,7 @@ ansible-playbook keycloak_realm_builder/scripts/custom_usage/playbook.yml -e act
 # setup realm and details for K6 testing:
 # - count = # of realms to be created
 # - for each k6 realm, the realm ID will be suffixed with incremental index
-# - please note that end of the play, there will output list of setting you need to config k6 tests
+# - please note that end of the play, there will console out and output .param file that you need to config k6 testing job
 ansible-playbook keycloak_realm_builder/scripts/custom_usage/playbook.yml -e action=k6-setup -e count=3
 
 # add new IDP for specific realm:

--- a/keycloak_realm_builder/scripts/custom_usage/readme.md
+++ b/keycloak_realm_builder/scripts/custom_usage/readme.md
@@ -56,8 +56,9 @@ ansible-playbook keycloak_realm_builder/scripts/custom_usage/playbook.yml -e act
 ansible-playbook keycloak_realm_builder/scripts/custom_usage/playbook.yml -e action=ocp4-setup
 
 # setup realm and details for K6 testing:
-# 1. count = # of realms to be created
-# 2. please note that end of the play, there will output list of setting you need to config k6 tests
+# - count = # of realms to be created
+# - for each k6 realm, the realm ID will be suffixed with incremental index
+# - please note that end of the play, there will output list of setting you need to config k6 tests
 ansible-playbook keycloak_realm_builder/scripts/custom_usage/playbook.yml -e action=k6-setup -e count=3
 
 # add new IDP for specific realm:

--- a/keycloak_realm_builder/scripts/custom_usage/readme.md
+++ b/keycloak_realm_builder/scripts/custom_usage/readme.md
@@ -21,7 +21,7 @@ This will delete the realm and its IDP integrations (IDIR/BCeID/GitHub/etc.)
 ## Steps to Run:
 1. setup keycloak service accounts
 ```shell
-cp creds/sample.sso-vars.yml creds/sso-vars.yml
+cp creds/sample.sso_vars.yml creds/sso_vars.yml
 # Fill in credentials:
 # - if running in prod SSO, make sure to enter the correct OTP
 # - if SiteMinder integration is needed, make sure the instance URL is `https://<env>.oidc.gov.bc.ca`
@@ -56,8 +56,9 @@ ansible-playbook keycloak_realm_builder/scripts/custom_usage/playbook.yml -e act
 ansible-playbook keycloak_realm_builder/scripts/custom_usage/playbook.yml -e action=ocp4-setup
 
 # setup realm and details for K6 testing:
-ansible-playbook keycloak_realm_builder/scripts/custom_usage/playbook.yml -e action=k6-setup
-# please note that end of the play, there will output list of setting you need to config k6 tests
+# 1. count = # of realms to be created
+# 2. please note that end of the play, there will output list of setting you need to config k6 tests
+ansible-playbook keycloak_realm_builder/scripts/custom_usage/playbook.yml -e action=k6-setup -e count=3
 
 # add new IDP for specific realm:
 ansible-playbook keycloak_realm_builder/scripts/custom_usage/playbook.yml -e action=new-idp
@@ -66,6 +67,6 @@ ansible-playbook keycloak_realm_builder/scripts/custom_usage/playbook.yml -e act
 ansible-playbook keycloak_realm_builder/scripts/custom_usage/playbook.yml -e action=enable-prod-bceid
 
 # delete realms and IDP integrations:
-ansible-playbook keycloak_realm_builder/scripts/custom_usage/playbook.yml -e action=delete-realm
+ansible-playbook keycloak_realm_builder/scripts/custom_usage/playbook.yml -e action=delete-real
 # make sure delete-realm.yml step <Setup idp names> is configured correctly
 ```

--- a/keycloak_realm_builder/scripts/custom_usage/readme.md
+++ b/keycloak_realm_builder/scripts/custom_usage/readme.md
@@ -68,6 +68,6 @@ ansible-playbook keycloak_realm_builder/scripts/custom_usage/playbook.yml -e act
 ansible-playbook keycloak_realm_builder/scripts/custom_usage/playbook.yml -e action=enable-prod-bceid
 
 # delete realms and IDP integrations:
-ansible-playbook keycloak_realm_builder/scripts/custom_usage/playbook.yml -e action=delete-real
+ansible-playbook keycloak_realm_builder/scripts/custom_usage/playbook.yml -e action=delete-realm
 # make sure delete-realm.yml step <Setup idp names> is configured correctly
 ```

--- a/keycloak_realm_builder/scripts/custom_usage/tasks/k6-main.yml
+++ b/keycloak_realm_builder/scripts/custom_usage/tasks/k6-main.yml
@@ -1,0 +1,30 @@
+---
+# tasks to create k6 testing realms
+- name: set increment realm name
+  set_fact:
+    increment_realm_id: "{{ realm_data.realm.id }}{{ item }}"
+
+- name: Update new realm config for "{{ increment_realm_id }}"
+  set_fact:
+    increment_realm_data: "{{ realm_data | combine(new_item, recursive=true) }}"
+  vars:
+    new_item: "{ '{{ item.key }}': { 'id': '{{ increment_realm_id }}' } }"
+  with_dict: "{{ realm_data }}"
+
+- name: Provision new SSO realms
+  include_tasks: sso-provisioning.yml
+  vars:
+  - realm_data: "{{ increment_realm_data }}"
+  with_items: 
+    - "{{ environments }}"
+  loop_control: 
+    loop_var: env
+
+- name: Config k6 realm
+  include_tasks: k6-setup.yml
+  vars:
+  - realm_data: "{{ increment_realm_data }}"
+  with_items: 
+    - "{{ environments }}"
+  loop_control: 
+    loop_var: env

--- a/keycloak_realm_builder/scripts/custom_usage/tasks/k6-main.yml
+++ b/keycloak_realm_builder/scripts/custom_usage/tasks/k6-main.yml
@@ -24,6 +24,7 @@
   include_tasks: k6-setup.yml
   vars:
   - realm_data: "{{ increment_realm_data }}"
+  - curr_index: "{{ item }}"
   with_items: 
     - "{{ environments }}"
   loop_control: 

--- a/keycloak_realm_builder/scripts/custom_usage/tasks/k6-setup.yml
+++ b/keycloak_realm_builder/scripts/custom_usage/tasks/k6-setup.yml
@@ -156,8 +156,13 @@
   loop: "{{ k6_usernames }}"
 
 ### ========================================================
-### Print Out Results:
+### Output result in param file:
+- name: Render Operator Deployment
+  template:
+    src: templates/k6-new-realms.param.j2
+    dest: new-realm-{{ realm }}-{{ env }}.param
 
+### Print Out Results in console:
 - debug:
     msg:
       - "+++++ Realm ID - {{ realm}}"

--- a/keycloak_realm_builder/scripts/custom_usage/tasks/k6-setup.yml
+++ b/keycloak_realm_builder/scripts/custom_usage/tasks/k6-setup.yml
@@ -157,7 +157,7 @@
 
 ### ========================================================
 ### Output result in param file:
-- name: Render Operator Deployment
+- name: Generate param file
   template:
     src: templates/k6-new-realms.param.j2
     dest: new-realm-{{ realm }}-{{ env }}.param

--- a/keycloak_realm_builder/scripts/custom_usage/tasks/templates/k6-new-realms.param.j2
+++ b/keycloak_realm_builder/scripts/custom_usage/tasks/templates/k6-new-realms.param.j2
@@ -1,0 +1,6 @@
+SSO_BASE_URL={{ keycloak_url }}
+SSO_REALM_{{ curr_index }}={{ realm }}
+SSO_CLIENT={{ k6_client_name }}
+USER_PASSWORD={{ k6_user_psw }}
+SSO_SA_CLIENT_ID={{ k6_api_client_name }}
+SSO_SA_CLIENT_PASSWORD_{{ curr_index }}={{ k6_api_client_secret }}


### PR DESCRIPTION
### Updates:
- add jinja2 template for k6 realm config output, as param file to be used for k6 oc template directly #27 
- enable multiple k6 test realms setup in one step