### PR TITLE
Create role report

### DIFF
--- a/realm-management/index.js
+++ b/realm-management/index.js
@@ -6,6 +6,8 @@ const { getAllRealms, getRealmSettings, getRealmUsers, getAllRealmAdmins, getRea
 // const { ssoServiceNameMigration } = require('./libs/service-name-migration');
 // const { deleteClientRole } = require('./libs/update-client-role');
 const { activeMonthlyUsersReport } = require('./libs/get-amu.js');
+const { realmRolesReport } = require('./libs/realms-without-roles.js');
+
 const { KC_CONFIG, KC_TERMS } = require('./constants');
 
 const main = async () => {
@@ -53,6 +55,9 @@ const main = async () => {
     // await deleteClientRole(KC_TERMS.IMPERSONATION_ROLE, false);
     // +++ Generate activeMonthlyUsersReport
     // const report = await activeMonthlyUsersReport(kcAdminClient);
+
+    // +++ Investigate realms without custom roles
+    await realmRolesReport(kcAdminClient);
 
   } catch (err) {
     throw Error(err);

--- a/realm-management/index.js
+++ b/realm-management/index.js
@@ -57,7 +57,7 @@ const main = async () => {
     // const report = await activeMonthlyUsersReport(kcAdminClient);
 
     // +++ Investigate realms without custom roles
-    await realmRolesReport(kcAdminClient);
+    // await realmRolesReport(kcAdminClient);
 
   } catch (err) {
     throw Error(err);

--- a/realm-management/libs/realms-without-roles.js
+++ b/realm-management/libs/realms-without-roles.js
@@ -1,0 +1,42 @@
+'use strict';
+
+/**
+ * Produce a report of number of roles per realm
+ * @param {kcAdmin} kcAdminClient with auth setup
+ */
+const realmRolesReport = async (kcAdminClient) => {  
+  console.log('**** Realm Roles Report ****\n');
+
+  let allRealms = (await kcAdminClient.realms.find());
+  allRealms = allRealms.filter(x => !['IDIR', 'github', 'bceid', 'tfrs'].includes(x.id));
+
+  let realmRoleInfos = allRealms.map( realm => {
+    return {
+      realm: realm.id,
+      realmName: realm.displayName,
+      allRoles: [],
+      defaultRoles: realm.defaultRoles,
+      nonDefaultRoles: [],
+    };
+  });
+
+  const promises = realmRoleInfos.map(async roleInfo => {
+    let allRoles = await kcAdminClient.roles.find( { realm: roleInfo.realm } );
+    roleInfo.allRoles = allRoles.map( r => r.name );
+    roleInfo.nonDefaultRoles = roleInfo.allRoles.filter(n => !roleInfo.defaultRoles.includes(n));
+  });
+
+  await Promise.all(promises);
+
+  console.log(`total # of realms: ${realmRoleInfos.length}`);
+
+  let realmsWithoutRoles = realmRoleInfos.filter( rri => rri.nonDefaultRoles.length == 0 );
+  console.log(`total # of realms without realm-level roles: ${realmsWithoutRoles.length}`);
+  let realmNames = realmsWithoutRoles.map( r => r.realmName ? r.realmName : r.realm ).sort();
+  for (const rwr of realmNames) {
+    console.log(`${rwr}`)
+  }
+
+}
+
+module.exports = { realmRolesReport };


### PR DESCRIPTION
Added a roles report, specifically trying to find out how many realms have never setup custom roles for role-based access control (RBAC). In DEV it looks like it's a lot (57 to be exact). Very curious to run this in production. It's all read-only calls to the API.